### PR TITLE
Update to Ice & Fire 2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,16 +61,16 @@ repositories {
 dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
-    //implementation fg.deobf("curse.maven:reachfix-${reachfix_version}")//Not released yet
+    implementation fg.deobf("curse.maven:reachfix-${reachfix_version}")//Not released yet
     implementation files("libs/ReachFix-1.12.2-1.0.7-rc4.jar")
     implementation fg.deobf("curse.maven:qualitytools-${qualitytools_version}")
     implementation fg.deobf("curse.maven:llibrary-${llibrary_version}")
     implementation fg.deobf("curse.maven:icenfire-${icenfire_version}")
     implementation fg.deobf("curse.maven:potioncore-${potioncore_version}")
-    //implementation fg.deobf("curse.maven:spartanweaponry-${spartanweaponry_version}")
+    implementation fg.deobf("curse.maven:spartanweaponry-${spartanweaponry_version}")
     implementation files("libs/SpartanWeaponry-1.12.2-1.5.0-indev-1.jar")
     implementation fg.deobf("curse.maven:reskillable-${reskillable_version}")
-    //implementation fg.deobf("curse.maven:bettersurvival-${bettersurvival_version}")
+    implementation fg.deobf("curse.maven:bettersurvival-${bettersurvival_version}")
     implementation files("libs/better_survival-1.4.2-BETA6.jar")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,14 +9,14 @@ forge_version=14.23.5.2860
 mappings_channel=stable
 mappings_version=39-1.12
 
-#reachfix_version=556777:3960250
+reachfix_version=556777:4633407
 qualitytools_version=264756:2732994
 llibrary_version=243298:2504999
-icenfire_version=264231:2693547
+icenfire_version=888556:4756949
 potioncore_version=242872:2905184
-#spartanweaponry_version=278141:3634012
+spartanweaponry_version=278141:3634012
 reskillable_version=286382:2815686
-#bettersurvival_version=
+bettersurvival_version=260360:4469260
 
 org.gradle.daemon=false
 org.gradle.jvmargs=-Xmx3G

--- a/src/main/java/bettercombat/mod/util/InFHandler.java
+++ b/src/main/java/bettercombat/mod/util/InFHandler.java
@@ -1,17 +1,17 @@
 package bettercombat.mod.util;
 
-import com.github.alexthe666.iceandfire.entity.EntityMutlipartPart;
+import com.github.alexthe666.iceandfire.entity.util.EntityMultipartPart;
 import net.minecraft.entity.Entity;
 
 public abstract class InFHandler {
 
     public static boolean isMultipart(Entity entity) {
-        return entity instanceof EntityMutlipartPart;
+        return entity instanceof EntityMultipartPart;
     }
 
     public static Entity getMultipartParent(Entity entity) {
-        if(entity instanceof EntityMutlipartPart) {
-            return (Entity)((EntityMutlipartPart)entity).getParent();
+        if(entity instanceof EntityMultipartPart) {
+            return ((EntityMultipartPart)entity).getParent();
         }
         return entity;
     }


### PR DESCRIPTION
This diff updates RLCombat to Ice & Fire 2.0 (of the Ice & Fire: RLCraft Edition fork). This version of Ice & Fire has made slight tweaks to the API, which is why this change is necessary.